### PR TITLE
Remove pom fix - and add check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,20 @@
+name: Check
+
+on: [ push, pull_request ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin' # See 'Supported distributions' for available options
+        java-version: '17'
+
+    - name: Build
+      run: ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main,  hotfix ]
 
 jobs:
   publish:
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK
       uses: actions/setup-java@v3
@@ -18,13 +18,10 @@ jobs:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '17'
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-
     - name: Build
       run: ./gradlew build
 
-    - name: Publish to Sonatype (for snapshots) or to Maven Central and Github Repository (for releases)
+    - name: Publish to Sonatype (for snapshots) or to Maven Central and GitHub Repository (for releases)
       run: ./gradlew publish closeAndReleaseRepository
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -87,17 +87,6 @@ publishing {
                     developerConnection = 'scm:git:git@github.com/JabRef/afterburner.fx.git'
                 }
             }
-
-            // Remove os-specific 'classifier' in pom for JavaFX dependency
-            // Taken from https://github.com/TestFX/Monocle/issues/64#issuecomment-489215444
-            pom.withXml {
-                Node pomNode = asNode()
-                pomNode.dependencies.'*'.findAll() {
-                    it.groupId.text() == 'org.openjfx'
-                }.each {
-                    it.remove(it.classifier)
-                }
-            }
         }
     }
     repositories {


### PR DESCRIPTION
Current build output: 

```
* Where:
Build file '/home/runner/work/afterburner.fx/afterburner.fx/build.gradle' line: 98

* What went wrong:
Execution failed for task ':generatePomFileForMavenJavaPublication'.
> Could not apply withXml() to generated POM
   > wrong number of arguments
```

It is not clear whether we need that fix 4 years later. Let's try without.

https://github.com/JabRef/afterburner.fx/blob/b5782ab87db0122c60c560fd5ada3ee154e987d9/build.gradle#L91
